### PR TITLE
Move orphaned package to the QA team

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: gitbrute
 Section: vcs
 Priority: optional
-Maintainer: Adam Borowski <kilobyte@angband.pl>
+Maintainer: Debian QA Group <packages@qa.debian.org>
 Build-Depends: debhelper-compat (=13), gccgo-go
 Standards-Version: 4.6.1
 Homepage: https://github.com/bradfitz/gitbrute


### PR DESCRIPTION
Move orphaned package to the QA team.

For details, see the [orphan bug](https://bugs.debian.org/1015773).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/orphan), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/orphan/pkg/gitbrute/944bbf38-dc40-4dc3-9f5c-ae394b6a7ccc.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Maintainer: [-Adam Borowski <kilobyte@angband.pl>-] {+Debian QA Group <packages@qa.debian.org>+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/944bbf38-dc40-4dc3-9f5c-ae394b6a7ccc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/944bbf38-dc40-4dc3-9f5c-ae394b6a7ccc/diffoscope)).
