### PR TITLE
Use canonical URL in Vcs-Git.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (=13), gccgo-go
 Standards-Version: 4.6.1
 Homepage: https://github.com/bradfitz/gitbrute
-Vcs-Git: https://github.com/kilobyte/gitbrute -b debian
+Vcs-Git: https://github.com/kilobyte/gitbrute.git -b debian
 Vcs-Browser: https://github.com/kilobyte/gitbrute/tree/debian
 Rules-Requires-Root: no
 


### PR DESCRIPTION

Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))


This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/gitbrute/cea7b26a-ec33-4046-9440-70f96bd26aa4.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/cea7b26a-ec33-4046-9440-70f96bd26aa4/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/cea7b26a-ec33-4046-9440-70f96bd26aa4/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/cea7b26a-ec33-4046-9440-70f96bd26aa4/diffoscope)).
